### PR TITLE
allow high quality simulcat packet to be forwarded

### DIFF
--- a/jvb/src/main/java/org/jitsi/videobridge/cc/allocation/BitrateControllerPacketHandler.java
+++ b/jvb/src/main/java/org/jitsi/videobridge/cc/allocation/BitrateControllerPacketHandler.java
@@ -161,6 +161,28 @@ class BitrateControllerPacketHandler
         return ssrc == adaptiveSourceProjection.getTargetSsrc();
     }
 
+    /**
+     * Return the target Ssrc fomr the packet. usefull for simulacast
+     *
+     * @param packetInfo that packet for which to decide whether to accept
+     * @return the target ssrc if found
+     * ; otherwise, <tt>-1</tt>
+     */
+    long getTargetSsrc(@NotNull PacketInfo packetInfo)
+    {
+        VideoRtpPacket videoRtpPacket = packetInfo.packetAs();
+        long ssrc = videoRtpPacket.getSsrc();
+
+        AdaptiveSourceProjection adaptiveSourceProjection = adaptiveSourceProjectionMap.get(ssrc);
+
+        if (adaptiveSourceProjection == null)
+        {
+		    return -1;
+        }
+
+        return adaptiveSourceProjection.getTargetSsrc();
+    }
+
     boolean transformRtcp(RtcpSrPacket rtcpSrPacket)
     {
         long ssrc = rtcpSrPacket.getSenderSsrc();

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/Endpoint.kt
@@ -910,7 +910,7 @@ class Endpoint @JvmOverloads constructor(
         return when (val packet = packetInfo.packet) {
 //            is VideoRtpPacket -> acceptVideo && bitrateController.accept(packetInfo)
             is VideoRtpPacket -> {
-                val ssrc = packet.ssrc
+                val ssrc = bitrateController.getTargetSsrc(packetInfo);
                 return acceptVideo && (perceptibles == null || perceptibleVideoSSRCs.contains(ssrc)) &&
                     bitrateController.accept(packetInfo)
             }

--- a/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BitrateController.kt
+++ b/jvb/src/main/kotlin/org/jitsi/videobridge/cc/allocation/BitrateController.kt
@@ -153,6 +153,7 @@ class BitrateController<T : MediaSourceContainer> @JvmOverloads constructor(
     }
     fun transformRtcp(rtcpSrPacket: RtcpSrPacket?): Boolean = packetHandler.transformRtcp(rtcpSrPacket)
     fun transformRtp(packetInfo: PacketInfo): Boolean = packetHandler.transformRtp(packetInfo)
+    fun getTargetSsrc(packetInfo: PacketInfo): Long = packetHandler.getTargetSsrc(packetInfo)
 
     val debugState: JSONObject
         get() = JSONObject().apply {


### PR DESCRIPTION
Hi,

I have been using your fork on another project,
and realized that the simulcast packets from the high-quality video layers were not forwarded.

This PR fixes it, so the frontend can send only the main video SSRC (as now), but the bridge will forward all packets from the layer (if the bitrate controller accept them)